### PR TITLE
Show the modal to ask users about their instance in all browsers

### DIFF
--- a/dist/mastodon.js
+++ b/dist/mastodon.js
@@ -1,22 +1,12 @@
 "use strict";
 
-const isFirefox = () => {
-  return typeof InstallTrigger !== 'undefined'
-}
-
 const COOKIE_NAME = 'instance-address'
 const URL_REGEX = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([\/\w .-]*)*\/?$/
 
 function msbShareButtonAction(name, target) {
   let msbInstanceAddress = ''
 
-  if (isFirefox()) {
-    let windowId = window.open(`web+mastodon://share?text=${name}%20${target}`, `__blank`)
-    return
-  }
-  else {
-    msbInstanceAddress = msbGetCookie('instance-address')
-  }
+  msbInstanceAddress = msbGetCookie('instance-address')
 
   if (msbInstanceAddress.length > 0) {
     window.open(`${msbInstanceAddress}/share?text=${name}%20${target}`, `__blank`)

--- a/index.html
+++ b/index.html
@@ -56,11 +56,7 @@
           <div class="card-body">
             <h5 class="card-title">Test it!</h5>
             <p class="card-text">
-              Bellow this card, you can click on the button. Its behavior depends on your browser.
-              <ul>
-                <li>On Firefox, it opens a new tab with Mastodon application.</li>
-                <li>Otherwise, a little modal will be displayed to ask to the user his/her instance.</li>
-              </ul>
+              Bellow this card, you can click on the button. A little modal will be displayed to ask to the user his/her instance.
             </p>
             <p class="card-text">
               <div 


### PR DESCRIPTION
There are some usability problems with the way the web+mastodon protocol is currently handled:

- The user is prompted to register the `web+mastodon` protocol handler by Mastodon only once, the first time the user visits an instance. If the user refuses at that time, there's no way to register it later.

- There's no easy way, as far as I know, to change the handler. That's a problem for users that have accounts in more than one instance.

I think that showing the modal to ask the users which instance they want to use in all browsers is far better.

Related issues:

- tootsuite/mastodon#6255

- #5 