### PR TITLE
Use const instead of hardcoded cookie name

### DIFF
--- a/dist/mastodon.js
+++ b/dist/mastodon.js
@@ -15,7 +15,7 @@ function msbShareButtonAction(name, target) {
     return
   }
   else {
-    msbInstanceAddress = msbGetCookie('instance-address')
+    msbInstanceAddress = msbGetCookie(COOKIE_NAME)
   }
 
   if (msbInstanceAddress.length > 0) {


### PR DESCRIPTION
There was a hardcoded cookie name string and I replaced it with the const COOKIE_NAME.