### PR TITLE
Adds https to instanceAddress

### DIFF
--- a/dist/mastodon.js
+++ b/dist/mastodon.js
@@ -31,6 +31,9 @@ function msbOnShare(_name, _target) {
     let target = !!_target ? _target : document.querySelector(msbConfig.buttonModalSelector).data.target
     let msbInstanceAddress = document.querySelector(`${msbConfig.addressFieldSelector}`).value
 
+    if (!msbInstanceAddress.startsWith('http')) {
+      msbInstanceAddress = 'https://' + msbInstanceAddress;
+    }
     if (msbInstanceAddress.match(URL_REGEX)) {
       if (msbConfig.memorizeFieldId) {
         let msbMemorizeIsChecked = document.querySelector(`#${msbConfig.memorizeFieldId}`).checked


### PR DESCRIPTION
Auto-fills the `https://` when users do not add protocol to `instanceAddress`.

[Various](https://social.coop/@Literally/109498519248153148) users reported this issue after implementation, same as #20  